### PR TITLE
Added support for self references (#10)

### DIFF
--- a/annotation-processor/src/main/kotlin/pl/touk/krush/KrushAnnotationProcessor.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/KrushAnnotationProcessor.kt
@@ -3,7 +3,9 @@ package pl.touk.krush
 import com.squareup.kotlinpoet.metadata.KotlinPoetMetadataPreview
 import pl.touk.krush.env.EnvironmentBuilder
 import pl.touk.krush.model.EntityGraphBuilder
+import pl.touk.krush.source.CopiedReferencesMappingsGenerator
 import pl.touk.krush.source.MappingsGenerator
+import pl.touk.krush.source.RealReferencesMappingsGenerator
 import pl.touk.krush.source.TablesGenerator
 import java.io.File
 import javax.annotation.processing.AbstractProcessor
@@ -50,7 +52,14 @@ class KrushAnnotationProcessor : AbstractProcessor() {
         if (graphs.isEmpty()) return false
 
         try {
-            val generators = listOf(TablesGenerator(), MappingsGenerator(generateRealReferences = generateRealReferences))
+            val mappingsGenerator: MappingsGenerator
+            if (generateRealReferences) {
+                mappingsGenerator = RealReferencesMappingsGenerator()
+            } else {
+                mappingsGenerator = CopiedReferencesMappingsGenerator()
+            }
+
+            val generators = listOf(TablesGenerator(), mappingsGenerator)
             generators.forEach { generator ->
                 graphs.entries.forEach { (packageName, graph) ->
                     val poetFile = generator.generate(graph, graphs, packageName, envBuilder.buildTypeEnv())

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/CopiedReferencesMappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/CopiedReferencesMappingsGenerator.kt
@@ -1,0 +1,103 @@
+package pl.touk.krush.source
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.asTypeName
+import org.jetbrains.exposed.sql.ResultRow
+import pl.touk.krush.model.*
+import pl.touk.krush.model.AssociationType.*
+import pl.touk.krush.validation.EntityNotMappedException
+import pl.touk.krush.validation.MissingIdException
+import javax.lang.model.element.TypeElement
+
+class CopiedReferencesMappingsGenerator : MappingsGenerator() {
+
+    override fun buildToEntityMapFunc(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
+        val rootKey = entity.id?.asTypeName() ?: throw MissingIdException(entity)
+
+        val rootVal = entity.name.asVariable()
+        val func = FunSpec.builder("to${entity.name}Map")
+                .receiver(Iterable::class.parameterizedBy(ResultRow::class))
+                .returns(ClassName("kotlin.collections", "MutableMap").parameterizedBy(rootKey, entityType.asType().asTypeName()))
+
+        val rootIdName = entity.id.name.asVariable()
+        val rootValId = "${rootVal}Id"
+
+        func.addStatement("val roots = mutableMapOf<$rootKey, ${entity.name}>()")
+        val associations = entity.getAssociations(ONE_TO_ONE, ONE_TO_MANY, MANY_TO_MANY)
+        associations.forEach { assoc ->
+            val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
+            val entityTypeName = entity.id.asTypeName()
+            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+            val associationMapValueType = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) "MutableSet<${target.name}>" else "${target.name}"
+
+            func.addStatement("val $associationMapName = mutableMapOf<${entityTypeName}, $associationMapValueType>()")
+            if (!(assoc.type == ONE_TO_ONE && assoc.mapped)) {
+                func.addStatement("val ${assoc.name}_map = this.to${assoc.target.simpleName}Map()")
+            }
+        }
+
+        func.addStatement("this.forEach { resultRow ->")
+        func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
+        func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
+        func.addStatement("\troots[$rootValId] = $rootVal")
+        associations.forEach { assoc ->
+            val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
+            val targetVal = target.name.asVariable()
+            val collName = "${assoc.name}_$rootVal"
+            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+
+            when (assoc.type) {
+                ONE_TO_MANY, MANY_TO_MANY -> {
+                    func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
+                    func.addStatement("\t\tval $collName = ${assoc.name}_map.filter { $targetVal -> $targetVal.key == it }")
+
+                    val isBidirectional = target.associations.find { it.target == entityType }?.mapped ?: false
+                    if (isBidirectional) {
+                        func.addStatement("\t\t\t.mapValues { (_, $targetVal) -> $targetVal.copy($rootVal = $rootVal) }")
+                    }
+
+                    func.addStatement("\t\t\t.values.toMutableSet()")
+                    func.addStatement("\t\t$associationMapName[$rootValId]?.addAll($collName) ?: $associationMapName.put($rootValId, $collName)")
+                    func.addStatement("\t}")
+                }
+
+                ONE_TO_ONE -> {
+                    if (!assoc.mapped) {
+                        func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
+                        func.addStatement("\t\t${assoc.name}_map.get(it)?.let {")
+                        func.addStatement("\t\t\t$associationMapName[$rootValId] = it")
+                        func.addStatement("\t\t}")
+                        func.addStatement("\t}")
+                    } else {
+                        func.addStatement("\tval ${assoc.name.asVariable()} = resultRow.to${target.name}()")
+                        func.addStatement("\t$associationMapName[${rootValId}] =  ${assoc.name.asVariable()}")
+                    }
+                }
+
+                else -> {}
+            }
+        }
+        func.addStatement("}")
+        func.addStatement("return roots.mapValues { (_, $rootVal) ->")
+        func.addStatement("\t${rootVal}.copy(")
+        associations.forEachIndexed { idx, assoc ->
+            val sep = if (idx == associations.lastIndex) "" else ","
+            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+            val value = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) {
+                "$associationMapName[$rootVal.$rootIdName]?.toList() ?: emptyList()"
+            } else {
+                "$associationMapName[$rootVal.$rootIdName]"
+            }
+
+            func.addStatement("\t\t${assoc.name} = $value$sep")
+
+        }
+        func.addStatement("\t)")
+        func.addStatement("}.toMutableMap()")
+
+        return func.build()
+    }
+
+}

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
@@ -164,7 +164,7 @@ class MappingsGenerator : SourceGenerator {
                         val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
                         val value = "$associationMapName[$rootVal.$rootIdName]"
 
-                        func.addStatement("\t\t${assoc.name} = $value$sep")
+                        func.addStatement("\t\t${assoc.name} = $value!!$sep")
 
                     }
             func.addStatement("\t)")

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
@@ -11,7 +11,7 @@ import pl.touk.krush.validation.EntityNotMappedException
 import pl.touk.krush.validation.MissingIdException
 import javax.lang.model.element.TypeElement
 
-class MappingsGenerator : SourceGenerator {
+class MappingsGenerator(private val generateRealReferences: Boolean) : SourceGenerator {
 
     override fun generate(graph: EntityGraph, graphs: EntityGraphs, packageName: String, typeEnv: TypeEnvironment): FileSpec {
         val fileSpec = FileSpec.builder(packageName, fileName = "mappings")
@@ -67,12 +67,17 @@ class MappingsGenerator : SourceGenerator {
                 .filter { assoc -> assoc.mapped }
                 .map { "\t${it.name} = this.to${it.target.simpleName}()"}
 
-        // Add empty but mutable lists for O2M and M2M connections, so that the relations can be filled in later
-        // without possibly breaking existing references to this object
-        val listAssociationMapping = entity.getAssociations(ONE_TO_MANY, MANY_TO_MANY)
-                .map { "\t${it.name} = mutableListOf()" }
+        val mapping: String
+        if(generateRealReferences){
+            // Add empty but mutable lists for O2M and M2M connections, so that the relations can be filled in later
+            // without possibly breaking existing references to this object
+            val listAssociationMapping = entity.getAssociations(ONE_TO_MANY, MANY_TO_MANY)
+                    .map { "\t${it.name} = mutableListOf()" }
 
-        val mapping = (propsMappings + embeddedMappings + associationsMappings + listAssociationMapping).joinToString(",\n")
+            mapping = (propsMappings + embeddedMappings + associationsMappings + listAssociationMapping).joinToString(",\n")
+        }else{
+            mapping = (propsMappings + embeddedMappings + associationsMappings).joinToString(",\n")
+        }
 
         func.addStatement("return %T(\n$mapping\n)", entityType.asType().asTypeName())
 
@@ -90,6 +95,101 @@ class MappingsGenerator : SourceGenerator {
     }
 
     private fun buildToEntityMapFunc(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
+        return if(generateRealReferences){
+            buildToEntityMapFuncWithRealReferences(entityType, entity, graphs)
+        }else{
+            buildToEntityMapFuncWithCopiedReferences(entityType, entity, graphs)
+        }
+    }
+
+    private fun buildToEntityMapFuncWithCopiedReferences(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
+        val rootKey = entity.id?.asTypeName() ?: throw MissingIdException(entity)
+
+        val rootVal = entity.name.asVariable()
+        val func = FunSpec.builder("to${entity.name}Map")
+                .receiver(Iterable::class.parameterizedBy(ResultRow::class))
+                .returns(ClassName("kotlin.collections", "MutableMap").parameterizedBy(rootKey, entityType.asType().asTypeName()))
+
+        val rootIdName = entity.id.name.asVariable()
+        val rootValId = "${rootVal}Id"
+
+        func.addStatement("val roots = mutableMapOf<$rootKey, ${entity.name}>()")
+        val associations = entity.getAssociations(ONE_TO_ONE, ONE_TO_MANY, MANY_TO_MANY)
+        associations.forEach { assoc ->
+            val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
+            val entityTypeName = entity.id.asTypeName()
+            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+            val associationMapValueType = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) "MutableSet<${target.name}>" else "${target.name}"
+
+            func.addStatement("val $associationMapName = mutableMapOf<${entityTypeName}, $associationMapValueType>()")
+            if (!(assoc.type == ONE_TO_ONE && assoc.mapped)) {
+                func.addStatement("val ${assoc.name}_map = this.to${assoc.target.simpleName}Map()")
+            }
+        }
+
+        func.addStatement("this.forEach { resultRow ->")
+        func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
+        func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
+        func.addStatement("\troots[$rootValId] = $rootVal")
+        associations.forEach { assoc ->
+            val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
+            val targetVal = target.name.asVariable()
+            val collName = "${assoc.name}_$rootVal"
+            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+
+            when (assoc.type) {
+                ONE_TO_MANY, MANY_TO_MANY -> {
+                    func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
+                    func.addStatement("\t\tval $collName = ${assoc.name}_map.filter { $targetVal -> $targetVal.key == it }")
+
+                    val isBidirectional = target.associations.find { it.target == entityType }?.mapped ?: false
+                    if (isBidirectional) {
+                        func.addStatement("\t\t\t.mapValues { (_, $targetVal) -> $targetVal.copy($rootVal = $rootVal) }")
+                    }
+
+                    func.addStatement("\t\t\t.values.toMutableSet()")
+                    func.addStatement("\t\t$associationMapName[$rootValId]?.addAll($collName) ?: $associationMapName.put($rootValId, $collName)")
+                    func.addStatement("\t}")
+                }
+
+                ONE_TO_ONE -> {
+                    if (!assoc.mapped) {
+                        func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
+                        func.addStatement("\t\t${assoc.name}_map.get(it)?.let {")
+                        func.addStatement("\t\t\t$associationMapName[$rootValId] = it")
+                        func.addStatement("\t\t}")
+                        func.addStatement("\t}")
+                    } else {
+                        func.addStatement("\tval ${assoc.name.asVariable()} = resultRow.to${target.name}()")
+                        func.addStatement("\t$associationMapName[${rootValId}] =  ${assoc.name.asVariable()}")
+                    }
+                }
+
+                else -> {}
+            }
+        }
+        func.addStatement("}")
+        func.addStatement("return roots.mapValues { (_, $rootVal) ->")
+        func.addStatement("\t${rootVal}.copy(")
+        associations.forEachIndexed { idx, assoc ->
+            val sep = if (idx == associations.lastIndex) "" else ","
+            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+            val value = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) {
+                "$associationMapName[$rootVal.$rootIdName]?.toList() ?: emptyList()"
+            } else {
+                "$associationMapName[$rootVal.$rootIdName]"
+            }
+
+            func.addStatement("\t\t${assoc.name} = $value$sep")
+
+        }
+        func.addStatement("\t)")
+        func.addStatement("}.toMutableMap()")
+
+        return func.build()
+    }
+
+    private fun buildToEntityMapFuncWithRealReferences(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
         val rootKey = entity.id?.asTypeName() ?: throw MissingIdException(entity)
 
         val rootVal = entity.name.asVariable()

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
@@ -11,7 +11,7 @@ import pl.touk.krush.validation.EntityNotMappedException
 import pl.touk.krush.validation.MissingIdException
 import javax.lang.model.element.TypeElement
 
-class MappingsGenerator(private val generateRealReferences: Boolean) : SourceGenerator {
+abstract class MappingsGenerator : SourceGenerator {
 
     override fun generate(graph: EntityGraph, graphs: EntityGraphs, packageName: String, typeEnv: TypeEnvironment): FileSpec {
         val fileSpec = FileSpec.builder(packageName, fileName = "mappings")
@@ -67,17 +67,12 @@ class MappingsGenerator(private val generateRealReferences: Boolean) : SourceGen
                 .filter { assoc -> assoc.mapped }
                 .map { "\t${it.name} = this.to${it.target.simpleName}()"}
 
-        val mapping: String
-        if (generateRealReferences) {
-            // Add empty but mutable lists for O2M and M2M connections, so that the relations can be filled in later
-            // without possibly breaking existing references to this object
-            val listAssociationMapping = entity.getAssociations(ONE_TO_MANY, MANY_TO_MANY)
-                    .map { "\t${it.name} = mutableListOf()" }
+        // Add empty but mutable lists for O2M and M2M connections, so that the relations can be filled in later
+        // without possibly breaking existing references to this object
+        val listAssociationMapping = entity.getAssociations(ONE_TO_MANY, MANY_TO_MANY)
+                .map { "\t${it.name} = mutableListOf()" }
 
-            mapping = (propsMappings + embeddedMappings + associationsMappings + listAssociationMapping).joinToString(",\n")
-        } else {
-            mapping = (propsMappings + embeddedMappings + associationsMappings).joinToString(",\n")
-        }
+        val mapping = (propsMappings + embeddedMappings + associationsMappings + listAssociationMapping).joinToString(",\n")
 
         func.addStatement("return %T(\n$mapping\n)", entityType.asType().asTypeName())
 
@@ -94,256 +89,7 @@ class MappingsGenerator(private val generateRealReferences: Boolean) : SourceGen
         return func.build()
     }
 
-    private fun buildToEntityMapFunc(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
-        return if (generateRealReferences) {
-            buildToEntityMapFuncWithRealReferences(entityType, entity, graphs)
-        } else {
-            buildToEntityMapFuncWithCopiedReferences(entityType, entity, graphs)
-        }
-    }
-
-    private fun buildToEntityMapFuncWithCopiedReferences(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
-        val rootKey = entity.id?.asTypeName() ?: throw MissingIdException(entity)
-
-        val rootVal = entity.name.asVariable()
-        val func = FunSpec.builder("to${entity.name}Map")
-                .receiver(Iterable::class.parameterizedBy(ResultRow::class))
-                .returns(ClassName("kotlin.collections", "MutableMap").parameterizedBy(rootKey, entityType.asType().asTypeName()))
-
-        val rootIdName = entity.id.name.asVariable()
-        val rootValId = "${rootVal}Id"
-
-        func.addStatement("val roots = mutableMapOf<$rootKey, ${entity.name}>()")
-        val associations = entity.getAssociations(ONE_TO_ONE, ONE_TO_MANY, MANY_TO_MANY)
-        associations.forEach { assoc ->
-            val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
-            val entityTypeName = entity.id.asTypeName()
-            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
-            val associationMapValueType = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) "MutableSet<${target.name}>" else "${target.name}"
-
-            func.addStatement("val $associationMapName = mutableMapOf<${entityTypeName}, $associationMapValueType>()")
-            if (!(assoc.type == ONE_TO_ONE && assoc.mapped)) {
-                func.addStatement("val ${assoc.name}_map = this.to${assoc.target.simpleName}Map()")
-            }
-        }
-
-        func.addStatement("this.forEach { resultRow ->")
-        func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
-        func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
-        func.addStatement("\troots[$rootValId] = $rootVal")
-        associations.forEach { assoc ->
-            val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
-            val targetVal = target.name.asVariable()
-            val collName = "${assoc.name}_$rootVal"
-            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
-
-            when (assoc.type) {
-                ONE_TO_MANY, MANY_TO_MANY -> {
-                    func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
-                    func.addStatement("\t\tval $collName = ${assoc.name}_map.filter { $targetVal -> $targetVal.key == it }")
-
-                    val isBidirectional = target.associations.find { it.target == entityType }?.mapped ?: false
-                    if (isBidirectional) {
-                        func.addStatement("\t\t\t.mapValues { (_, $targetVal) -> $targetVal.copy($rootVal = $rootVal) }")
-                    }
-
-                    func.addStatement("\t\t\t.values.toMutableSet()")
-                    func.addStatement("\t\t$associationMapName[$rootValId]?.addAll($collName) ?: $associationMapName.put($rootValId, $collName)")
-                    func.addStatement("\t}")
-                }
-
-                ONE_TO_ONE -> {
-                    if (!assoc.mapped) {
-                        func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
-                        func.addStatement("\t\t${assoc.name}_map.get(it)?.let {")
-                        func.addStatement("\t\t\t$associationMapName[$rootValId] = it")
-                        func.addStatement("\t\t}")
-                        func.addStatement("\t}")
-                    } else {
-                        func.addStatement("\tval ${assoc.name.asVariable()} = resultRow.to${target.name}()")
-                        func.addStatement("\t$associationMapName[${rootValId}] =  ${assoc.name.asVariable()}")
-                    }
-                }
-
-                else -> {}
-            }
-        }
-        func.addStatement("}")
-        func.addStatement("return roots.mapValues { (_, $rootVal) ->")
-        func.addStatement("\t${rootVal}.copy(")
-        associations.forEachIndexed { idx, assoc ->
-            val sep = if (idx == associations.lastIndex) "" else ","
-            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
-            val value = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) {
-                "$associationMapName[$rootVal.$rootIdName]?.toList() ?: emptyList()"
-            } else {
-                "$associationMapName[$rootVal.$rootIdName]"
-            }
-
-            func.addStatement("\t\t${assoc.name} = $value$sep")
-
-        }
-        func.addStatement("\t)")
-        func.addStatement("}.toMutableMap()")
-
-        return func.build()
-    }
-
-    private fun buildToEntityMapFuncWithRealReferences(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
-        val rootKey = entity.id?.asTypeName() ?: throw MissingIdException(entity)
-
-        val rootVal = entity.name.asVariable()
-        val func = FunSpec.builder("to${entity.name}Map")
-                .receiver(Iterable::class.parameterizedBy(ResultRow::class))
-                .returns(ClassName("kotlin.collections", "MutableMap").parameterizedBy(rootKey, entityType.asType().asTypeName()))
-
-        val rootIdName = entity.id.name.asVariable()
-        val rootValId = "${rootVal}Id"
-
-        func.addStatement("var roots = mutableMapOf<$rootKey, ${entity.name}>()")
-
-        // Add all non-relational data
-        func.addStatement("this.forEach { resultRow ->")
-        func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
-        func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
-        func.addStatement("\troots[$rootValId] = $rootVal")
-        func.addStatement("}")
-
-        val associations = entity.getAssociations(ONE_TO_ONE, ONE_TO_MANY, MANY_TO_MANY)
-        associations.forEach { assoc ->
-            val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
-            val entityTypeName = entity.id.asTypeName()
-            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
-            val associationMapValueType = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) "MutableSet<${target.name}>" else "${target.name}"
-
-            func.addStatement("val $associationMapName = mutableMapOf<${entityTypeName}, $associationMapValueType>()")
-            if (!(assoc.type == ONE_TO_ONE && assoc.mapped)) {
-                val isSelfReferential = assoc.target == entityType
-
-                // Prevent infinite recursions
-                // (when the table is self-referential, roots will be used as "foreign map" - see below)
-                if (!isSelfReferential) {
-                    func.addStatement("val ${assoc.name}_map = this.to${assoc.target.simpleName}Map()")
-                }
-
-            }
-        }
-
-        // Add O2O relational data first, because it recreates the entity objects which destroys potential object references
-        if (associations.any { it.type == ONE_TO_ONE }) {
-            func.addStatement("this.forEach { resultRow ->")
-            func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
-            func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
-            associations.forEach { assoc ->
-                if (assoc.type != ONE_TO_ONE) {
-                    return@forEach
-                }
-
-                val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
-                val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
-
-                if (!assoc.mapped) {
-                    func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
-                    func.addStatement("\t\t${assoc.name}_map.get(it)?.let {")
-                    func.addStatement("\t\t\t$associationMapName[$rootValId] = it")
-                    func.addStatement("\t\t}")
-                    func.addStatement("\t}")
-                } else {
-                    func.addStatement("\tval ${assoc.name.asVariable()} = resultRow.to${target.name}()")
-                    func.addStatement("\t$associationMapName[${rootValId}] =  ${assoc.name.asVariable()}")
-                }
-            }
-            func.addStatement("}")
-
-            func.addStatement("roots = roots.mapValues { (_, $rootVal) ->")
-            func.addStatement("\t${rootVal}.copy(")
-            associations
-                    .filter { it.type == ONE_TO_ONE }
-                    .forEachIndexed { idx, assoc ->
-                        val sep = if (idx == associations.lastIndex) "" else ","
-                        val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
-                        val value = "$associationMapName[$rootVal.$rootIdName]"
-
-                        func.addStatement("\t\t${assoc.name} = $value ?: $rootVal.${assoc.name}$sep")
-
-                    }
-            func.addStatement("\t)")
-            func.addStatement("}.toMutableMap()")
-        }
-
-        // Add O2M and M2M relations
-        if (associations.any { it.type == ONE_TO_MANY || it.type == MANY_TO_MANY }) {
-
-            // Add list relational data (this is done in a separate step so that self-referential relations work)
-            func.addStatement("this.forEach { resultRow ->")
-            func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
-            func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
-            associations.forEach { assoc ->
-                val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
-                val targetVal = target.name.asVariable()
-                val collName = "${assoc.name}_$rootVal"
-                val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
-
-                // Use self as "foreign" table if the table is self-referential
-                val isSelfReferential = assoc.target == entityType
-
-                val foreignTableMap: String
-                if (!isSelfReferential) {
-                    foreignTableMap = "${assoc.name}_map"
-                } else {
-                    foreignTableMap = "roots"
-                }
-
-                when (assoc.type) {
-                    ONE_TO_MANY -> {
-                        func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
-                        func.addStatement("\t\tval $collName = $foreignTableMap.filter { $targetVal -> $targetVal.key == it }")
-
-                        val isBidirectional = target.associations.find { it.target == entityType }?.mapped ?: false
-                        if (isBidirectional) {
-                            func.addStatement("\t\t\t.mapValues { (_, $targetVal) -> $targetVal.copy($rootVal = $rootVal) }")
-                        }
-
-                        func.addStatement("\t\t\t.values.toMutableSet()")
-                        func.addStatement("\t\t$associationMapName[$rootValId]?.addAll($collName) ?: $associationMapName.put($rootValId, $collName)")
-                        func.addStatement("\t}")
-                    }
-
-                    MANY_TO_MANY -> {
-                        val assocTableTargetIdCol = "${entity.name}${assoc.name.asObject()}Table.${targetVal}TargetId"
-
-                        func.addStatement("\tresultRow.getOrNull($assocTableTargetIdCol)?.let {")
-                        func.addStatement("\t\tval $collName = $foreignTableMap.filter { $targetVal -> $targetVal.key == it }")
-
-                        func.addStatement("\t\t\t.values.toMutableSet()")
-                        func.addStatement("\t\t$associationMapName[$rootValId]?.addAll($collName) ?: $associationMapName.put($rootValId, $collName)")
-                        func.addStatement("\t}")
-                    }
-
-                    else -> {}
-                }
-            }
-            func.addStatement("}")
-
-            func.addStatement("roots.forEach { (_, $rootVal) ->")
-            associations.forEach { assoc ->
-                if (assoc.type !in listOf(ONE_TO_MANY, MANY_TO_MANY)) {
-                    return@forEach
-                }
-
-                val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
-                func.addStatement("\t\tval ${associationMapName}_relations = $associationMapName[$rootVal.$rootIdName]?.toList()")
-                func.addStatement("\t\tif (${associationMapName}_relations != null) {")
-                func.addStatement("\t\t\t($rootVal.${assoc.name} as MutableList).addAll(${associationMapName}_relations)")
-                func.addStatement("\t\t}")
-            }
-            func.addStatement("\t}")
-        }
-
-        func.addStatement("return roots")
-
-        return func.build()
-    }
+    protected abstract fun buildToEntityMapFunc(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec
 
     private fun buildFromEntityFunc(entityType: TypeElement, entity: EntityDefinition): FunSpec? {
         val param = entity.name.asVariable()

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
@@ -164,7 +164,7 @@ class MappingsGenerator : SourceGenerator {
                         val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
                         val value = "$associationMapName[$rootVal.$rootIdName]"
 
-                        func.addStatement("\t\t${assoc.name} = $value!!$sep")
+                        func.addStatement("\t\t${assoc.name} = $value ?: $rootVal.${assoc.name}$sep")
 
                     }
             func.addStatement("\t)")

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/RealReferencesMappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/RealReferencesMappingsGenerator.kt
@@ -1,0 +1,172 @@
+package pl.touk.krush.source
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.asTypeName
+import org.jetbrains.exposed.sql.ResultRow
+import pl.touk.krush.model.*
+import pl.touk.krush.model.AssociationType.*
+import pl.touk.krush.validation.EntityNotMappedException
+import pl.touk.krush.validation.MissingIdException
+import javax.lang.model.element.TypeElement
+
+class RealReferencesMappingsGenerator : MappingsGenerator() {
+
+    override fun buildToEntityMapFunc(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
+        val rootKey = entity.id?.asTypeName() ?: throw MissingIdException(entity)
+
+        val rootVal = entity.name.asVariable()
+        val func = FunSpec.builder("to${entity.name}Map")
+                .receiver(Iterable::class.parameterizedBy(ResultRow::class))
+                .returns(ClassName("kotlin.collections", "MutableMap").parameterizedBy(rootKey, entityType.asType().asTypeName()))
+
+        val rootIdName = entity.id.name.asVariable()
+        val rootValId = "${rootVal}Id"
+
+        func.addStatement("var roots = mutableMapOf<$rootKey, ${entity.name}>()")
+
+        // Add all non-relational data
+        func.addStatement("this.forEach { resultRow ->")
+        func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
+        func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
+        func.addStatement("\troots[$rootValId] = $rootVal")
+        func.addStatement("}")
+
+        val associations = entity.getAssociations(ONE_TO_ONE, ONE_TO_MANY, MANY_TO_MANY)
+        associations.forEach { assoc ->
+            val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
+            val entityTypeName = entity.id.asTypeName()
+            val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+            val associationMapValueType = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) "MutableSet<${target.name}>" else "${target.name}"
+
+            func.addStatement("val $associationMapName = mutableMapOf<${entityTypeName}, $associationMapValueType>()")
+            if (!(assoc.type == ONE_TO_ONE && assoc.mapped)) {
+                val isSelfReferential = assoc.target == entityType
+
+                // Prevent infinite recursions
+                // (when the table is self-referential, roots will be used as "foreign map" - see below)
+                if (!isSelfReferential) {
+                    func.addStatement("val ${assoc.name}_map = this.to${assoc.target.simpleName}Map()")
+                }
+
+            }
+        }
+
+        // Add O2O relational data first, because it recreates the entity objects which destroys potential object references
+        if (associations.any { it.type == ONE_TO_ONE }) {
+            func.addStatement("this.forEach { resultRow ->")
+            func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
+            func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
+            associations.forEach { assoc ->
+                if (assoc.type != ONE_TO_ONE) {
+                    return@forEach
+                }
+
+                val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
+                val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+
+                if (!assoc.mapped) {
+                    func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
+                    func.addStatement("\t\t${assoc.name}_map.get(it)?.let {")
+                    func.addStatement("\t\t\t$associationMapName[$rootValId] = it")
+                    func.addStatement("\t\t}")
+                    func.addStatement("\t}")
+                } else {
+                    func.addStatement("\tval ${assoc.name.asVariable()} = resultRow.to${target.name}()")
+                    func.addStatement("\t$associationMapName[${rootValId}] =  ${assoc.name.asVariable()}")
+                }
+            }
+            func.addStatement("}")
+
+            func.addStatement("roots = roots.mapValues { (_, $rootVal) ->")
+            func.addStatement("\t${rootVal}.copy(")
+            associations
+                    .filter { it.type == ONE_TO_ONE }
+                    .forEachIndexed { idx, assoc ->
+                        val sep = if (idx == associations.lastIndex) "" else ","
+                        val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+                        val value = "$associationMapName[$rootVal.$rootIdName]"
+
+                        func.addStatement("\t\t${assoc.name} = $value ?: $rootVal.${assoc.name}$sep")
+
+                    }
+            func.addStatement("\t)")
+            func.addStatement("}.toMutableMap()")
+        }
+
+        // Add O2M and M2M relations
+        if (associations.any { it.type == ONE_TO_MANY || it.type == MANY_TO_MANY }) {
+
+            // Add list relational data (this is done in a separate step so that self-referential relations work)
+            func.addStatement("this.forEach { resultRow ->")
+            func.addStatement("\tval $rootValId = resultRow.getOrNull(${entity.name}Table.${entity.id.name}) ?: return@forEach")
+            func.addStatement("\tval $rootVal = roots[$rootValId] ?: resultRow.to${entity.name}()")
+            associations.forEach { assoc ->
+                val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
+                val targetVal = target.name.asVariable()
+                val collName = "${assoc.name}_$rootVal"
+                val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+
+                // Use self as "foreign" table if the table is self-referential
+                val isSelfReferential = assoc.target == entityType
+
+                val foreignTableMap: String
+                if (!isSelfReferential) {
+                    foreignTableMap = "${assoc.name}_map"
+                } else {
+                    foreignTableMap = "roots"
+                }
+
+                when (assoc.type) {
+                    ONE_TO_MANY -> {
+                        func.addStatement("\tresultRow.getOrNull(${target.idColumn})?.let {")
+                        func.addStatement("\t\tval $collName = $foreignTableMap.filter { $targetVal -> $targetVal.key == it }")
+
+                        val isBidirectional = target.associations.find { it.target == entityType }?.mapped ?: false
+                        if (isBidirectional) {
+                            func.addStatement("\t\t\t.mapValues { (_, $targetVal) -> $targetVal.copy($rootVal = $rootVal) }")
+                        }
+
+                        func.addStatement("\t\t\t.values.toMutableSet()")
+                        func.addStatement("\t\t$associationMapName[$rootValId]?.addAll($collName) ?: $associationMapName.put($rootValId, $collName)")
+                        func.addStatement("\t}")
+                    }
+
+                    MANY_TO_MANY -> {
+                        val assocTableTargetIdCol = "${entity.name}${assoc.name.asObject()}Table.${targetVal}TargetId"
+
+                        func.addStatement("\tresultRow.getOrNull($assocTableTargetIdCol)?.let {")
+                        func.addStatement("\t\tval $collName = $foreignTableMap.filter { $targetVal -> $targetVal.key == it }")
+
+                        func.addStatement("\t\t\t.values.toMutableSet()")
+                        func.addStatement("\t\t$associationMapName[$rootValId]?.addAll($collName) ?: $associationMapName.put($rootValId, $collName)")
+                        func.addStatement("\t}")
+                    }
+
+                    else -> {}
+                }
+            }
+            func.addStatement("}")
+
+            func.addStatement("roots.forEach { (_, $rootVal) ->")
+            associations.forEach { assoc ->
+                if (assoc.type !in listOf(ONE_TO_MANY, MANY_TO_MANY)) {
+                    return@forEach
+                }
+
+                val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
+                func.addStatement("\t\tval ${associationMapName}_relations = $associationMapName[$rootVal.$rootIdName]?.toList()")
+                func.addStatement("\t\tif (${associationMapName}_relations != null) {")
+                func.addStatement("\t\t\t($rootVal.${assoc.name} as MutableList).addAll(${associationMapName}_relations)")
+                func.addStatement("\t\t}")
+            }
+            func.addStatement("\t}")
+        }
+
+        func.addStatement("return roots")
+
+        return func.build()
+    }
+
+}

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/TablesGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/TablesGenerator.kt
@@ -105,8 +105,8 @@ class TablesGenerator : SourceGenerator {
 
                 val sourceType = entity.id.type.asClassName()
                 manyToManyTableSpec.addProperty(
-                        PropertySpec.builder("${rootVal}Id", Column::class.asClassName().parameterizedBy(sourceType))
-                                .initializer(manyToManyPropertyInitializer(entity.id, entity))
+                        PropertySpec.builder("${rootVal}SourceId", Column::class.asClassName().parameterizedBy(sourceType))
+                                .initializer(manyToManyPropertyInitializer(entity.id, entity, "_source"))
                                 .build()
                 )
 
@@ -114,8 +114,8 @@ class TablesGenerator : SourceGenerator {
                 val targetEntityDef = graphs.entity(assoc.target.packageName, assoc.target) ?:
                     throw AssociationTargetEntityNotFoundException(assoc.target)
                 manyToManyTableSpec.addProperty(
-                        PropertySpec.builder("${targetVal}Id", Column::class.asClassName().parameterizedBy(targetIdType))
-                                .initializer(manyToManyPropertyInitializer(assoc.targetId, targetEntityDef))
+                        PropertySpec.builder("${targetVal}TargetId", Column::class.asClassName().parameterizedBy(targetIdType))
+                                .initializer(manyToManyPropertyInitializer(assoc.targetId, targetEntityDef, "_target"))
                                 .build()
                 )
 
@@ -306,8 +306,8 @@ class TablesGenerator : SourceGenerator {
                 .build()
     }
 
-    private fun manyToManyPropertyInitializer(id: IdDefinition, entity: EntityDefinition) : CodeBlock {
-        val columnName = entity.name.asVariable() + "_id"
+    private fun manyToManyPropertyInitializer(id: IdDefinition, entity: EntityDefinition, differentiatior: String) : CodeBlock {
+        val columnName = entity.name.asVariable() + differentiatior + "_id"
         val idCodeBlock = idCodeBlock(id, entity.name, columnName)
 
         return CodeBlock.builder().add(idCodeBlock)

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -22,3 +22,11 @@ tasks.test {
         events("passed", "skipped", "failed")
     }
 }
+
+// Uncomment to enable generating code that creates objects with references to their real counterparts
+// instead of copies. Incompatible with bidirectional relations.
+/*kapt {
+    arguments {
+        arg("krush.references", 'real')
+    }
+}*/

--- a/example/src/main/kotlin/pl/touk/krush/many2many/Task.kt
+++ b/example/src/main/kotlin/pl/touk/krush/many2many/Task.kt
@@ -2,8 +2,7 @@ package pl.touk.krush.many2many
 
 import javax.persistence.*
 
-// Uncomment to test M2M with real references (requires krush.references to be set to real)
-/*@Entity
+@Entity
 @Table(name = "tasks")
 data class Task(
 
@@ -15,4 +14,4 @@ data class Task(
         @JoinTable(name = "task_requirements")
         @ManyToMany
         val requirements: Collection<Task> = emptyList()
-)*/
+)

--- a/example/src/main/kotlin/pl/touk/krush/many2many/Task.kt
+++ b/example/src/main/kotlin/pl/touk/krush/many2many/Task.kt
@@ -2,7 +2,8 @@ package pl.touk.krush.many2many
 
 import javax.persistence.*
 
-@Entity
+// Uncomment to test M2M with real references (requires krush.references to be set to real)
+/*@Entity
 @Table(name = "tasks")
 data class Task(
 
@@ -14,4 +15,4 @@ data class Task(
         @JoinTable(name = "task_requirements")
         @ManyToMany
         val requirements: Collection<Task> = emptyList()
-)
+)*/

--- a/example/src/main/kotlin/pl/touk/krush/many2many/Task.kt
+++ b/example/src/main/kotlin/pl/touk/krush/many2many/Task.kt
@@ -1,0 +1,17 @@
+package pl.touk.krush.many2many
+
+import javax.persistence.*
+
+@Entity
+@Table(name = "tasks")
+data class Task(
+
+        @Id @GeneratedValue
+        val id: Long? = null,
+
+        val description: String = "",
+
+        @JoinTable(name = "task_requirements")
+        @ManyToMany
+        val requirements: Collection<Task> = emptyList()
+)

--- a/example/src/test/kotlin/pl/touk/krush/many2many/TaskTest.kt
+++ b/example/src/test/kotlin/pl/touk/krush/many2many/TaskTest.kt
@@ -6,13 +6,14 @@ import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import pl.touk.krush.base.BaseDatabaseTest
 
-// Uncomment to test M2M with real references (requires krush.references to be set to real)
-/*class TaskTest : BaseDatabaseTest() {
+class TaskTest : BaseDatabaseTest() {
 
     @Test
+    @Disabled("Uncomment to test M2M with real references (requires krush.references to be set to real)")
     fun shouldHandleSelfReferences() {
         transaction {
             SchemaUtils.create(TaskTable, TaskRequirementsTable)
@@ -38,4 +39,4 @@ import pl.touk.krush.base.BaseDatabaseTest
         }
     }
 
-}*/
+}

--- a/example/src/test/kotlin/pl/touk/krush/many2many/TaskTest.kt
+++ b/example/src/test/kotlin/pl/touk/krush/many2many/TaskTest.kt
@@ -13,7 +13,7 @@ import pl.touk.krush.base.BaseDatabaseTest
 /*class TaskTest : BaseDatabaseTest() {
 
     @Test
-    fun shouldHandleSelfReferences(){
+    fun shouldHandleSelfReferences() {
         transaction {
             SchemaUtils.create(TaskTable, TaskRequirementsTable)
 

--- a/example/src/test/kotlin/pl/touk/krush/many2many/TaskTest.kt
+++ b/example/src/test/kotlin/pl/touk/krush/many2many/TaskTest.kt
@@ -1,0 +1,40 @@
+package pl.touk.krush.many2many
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.exposed.sql.Join
+import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Test
+import pl.touk.krush.base.BaseDatabaseTest
+
+class TaskTest : BaseDatabaseTest() {
+
+    @Test
+    fun shouldHandleSelfReferences(){
+        transaction {
+            SchemaUtils.create(TaskTable, TaskRequirementsTable)
+
+            // given
+            val task1 = TaskTable.insert(Task(description = "Collect underpants"))
+            val task2 = TaskTable.insert(Task(description = "?", requirements = listOf(task1)))
+            val task3 = TaskTable.insert(Task(description = "Profit!", requirements = listOf(task1, task2)))
+
+            // when
+            val selectedTasks = Join(
+                    table = TaskTable,
+                    otherTable = TaskRequirementsTable,
+                    joinType = JoinType.LEFT,
+                    onColumn = TaskTable.id,
+                    otherColumn = TaskRequirementsTable.taskSourceId
+            ).selectAll().toTaskList()
+
+            // then
+            val expectation = listOf(task1, task2, task3)
+
+            assertThat(selectedTasks).isEqualTo(expectation)
+        }
+    }
+
+}

--- a/example/src/test/kotlin/pl/touk/krush/many2many/TaskTest.kt
+++ b/example/src/test/kotlin/pl/touk/krush/many2many/TaskTest.kt
@@ -9,7 +9,8 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.Test
 import pl.touk.krush.base.BaseDatabaseTest
 
-class TaskTest : BaseDatabaseTest() {
+// Uncomment to test M2M with real references (requires krush.references to be set to real)
+/*class TaskTest : BaseDatabaseTest() {
 
     @Test
     fun shouldHandleSelfReferences(){
@@ -37,4 +38,4 @@ class TaskTest : BaseDatabaseTest() {
         }
     }
 
-}
+}*/


### PR DESCRIPTION
I found this project appealing enough to implement this myself :D

I added support for objects having M2M-relations to themselves by distinguishing the attributes of the join-table with "source" and "target" keywords, and changed `buildToEntityMapFunc()` to avoid infinite recursions in that case (and it also now passes the proper object references of related objects).

Because this PR changes how krush expects a join-table to look, this can be considered a breaking change.

Also: I did not do much testing of this change apart from running the unit tests and testing it with my use case (~~both work without issue~~ Looks like I overlooked the "example" tests - will look into this), so this will likely need to be tested with more examples before it can be merged with confidence that there will be no unfortunate surprises.