### PR TITLE
Add support for type aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Maven:
 * generates table mappings and functions for mapping from/to data classes
 * type-safe SQL DSL without reading schema from existing database (code-first)
 * explicit association fetching (via `leftJoin` / `innerJoin`)
-* multiple data types support
+* multiple data types support, including type aliases
 * custom data type support (with `@Converter`), also for wrapped auto-generated ids
 * you can still persist associations not directly reflected in domain model (eq. article favorites) 
 

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/model/ColumnProcessor.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/model/ColumnProcessor.kt
@@ -155,8 +155,15 @@ class ColumnProcessor(override val typeEnv: TypeEnvironment, private val annEnv:
     }
 
     private fun ImmutableKmType.toModelType(): Type? {
-        return (this.classifier as KmClassifier.Class).name
-                .split("/").let { Type(it.dropLast(1).joinToString(separator = "."), it.last()) }
+        return when(val classifier = (this.abbreviatedType?.classifier ?: this.classifier)){
+            is KmClassifier.Class -> {
+                classifier.name
+                    .split("/").let { Type(it.dropLast(1).joinToString(separator = "."), it.last()) }
+            }
+            is KmClassifier.TypeAlias -> classifier.name
+                    .split("/").let { Type(it.dropLast(1).joinToString(separator = "."), it.last(), this.copy(abbreviatedType = null).toModelType()) }
+            is KmClassifier.TypeParameter -> TODO()
+        }
     }
 
     private fun String.name(): Name = typeEnv.elementUtils.getName(this)

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/model/EntityDefinition.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/model/EntityDefinition.kt
@@ -95,7 +95,8 @@ enum class EnumType {
 
 data class Type(
         val packageName: String,
-        val simpleName: String
+        val simpleName: String,
+        val aliasOf: Type? = null
 )
 
 data class EmbeddableDefinition(

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/model/ModelValidator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/model/ModelValidator.kt
@@ -97,7 +97,7 @@ class EntityPropertyTypeValidator : Validator<EntityDefinition> {
 
     override fun validate(el: EntityDefinition): ValidationResult {
         val errors = mutableListOf<ValidationErrorMessage>()
-        el.properties.filter { !it.hasConverter() && !it.isEnumerated() && it.type !in supportedPropertyTypes }.forEach {
+        el.properties.filter { !it.hasConverter() && !it.isEnumerated() && it.type !in supportedPropertyTypes && it.type.aliasOf !in supportedPropertyTypes }.forEach {
             errors.add(ValidationErrorMessage("Entity ${el.qualifiedName} has unsupported property type ${it.type}"))
         }
 

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/CopiedReferencesMappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/CopiedReferencesMappingsGenerator.kt
@@ -15,7 +15,7 @@ class CopiedReferencesMappingsGenerator : MappingsGenerator() {
         val associations = entity.getAssociations(ONE_TO_ONE, ONE_TO_MANY, MANY_TO_MANY)
         associations.forEach { assoc ->
             val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
-            val entityIdTypeName = entityId.asTypeName()
+            val entityIdTypeName = entityId.asUnderlyingTypeName()
             val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
             val associationMapValueType = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) "MutableSet<${target.name}>" else "${target.name}"
 

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/MappingsGenerator.kt
@@ -90,7 +90,7 @@ abstract class MappingsGenerator : SourceGenerator {
     }
 
     private fun buildToEntityMapFunc(entityType: TypeElement, entity: EntityDefinition, graphs: EntityGraphs): FunSpec {
-        val rootKey = entity.id?.asTypeName() ?: throw MissingIdException(entity)
+        val rootKey = entity.id?.asUnderlyingTypeName() ?: throw MissingIdException(entity)
 
         val rootVal = entity.name.asVariable()
         val func = FunSpec.builder("to${entity.name}Map")

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/RealReferencesMappingsGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/RealReferencesMappingsGenerator.kt
@@ -23,7 +23,7 @@ class RealReferencesMappingsGenerator : MappingsGenerator() {
         val associations = entity.getAssociations(ONE_TO_ONE, ONE_TO_MANY, MANY_TO_MANY)
         associations.forEach { assoc ->
             val target = graphs[assoc.target.packageName]?.get(assoc.target) ?: throw EntityNotMappedException(assoc.target)
-            val entityIdTypeName = entityId.asTypeName()
+            val entityIdTypeName = entityId.asUnderlyingTypeName()
             val associationMapName = "${entity.name.asVariable()}_${assoc.name}"
             val associationMapValueType = if (assoc.type in listOf(ONE_TO_MANY, MANY_TO_MANY)) "MutableSet<${target.name}>" else "${target.name}"
 

--- a/annotation-processor/src/test/kotlin/pl/touk/example/ValidTableMapping.kt
+++ b/annotation-processor/src/test/kotlin/pl/touk/example/ValidTableMapping.kt
@@ -3,17 +3,8 @@ package pl.touk.example
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
-import javax.persistence.Column
-import javax.persistence.Embeddable
-import javax.persistence.Embedded
-import javax.persistence.Entity
+import javax.persistence.*
 import javax.persistence.EnumType.STRING
-import javax.persistence.Enumerated
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
-import javax.persistence.JoinColumn
-import javax.persistence.OneToOne
-import javax.persistence.Table
 
 @Entity
 data class DefaultPropertyNameEntity(
@@ -47,6 +38,29 @@ data class NullablePropertyEntity(
 
         val prop1: String?
 )
+
+typealias StringMap = Map<String, String>
+typealias PlainString = String
+
+@Entity
+data class TypeAliasEntity(
+        @Id @GeneratedValue
+        val id: Long?,
+        @Convert(converter = StringMapConverter::class)
+        val aliased: StringMap,
+        val justAString: PlainString
+)
+
+@Converter
+class StringMapConverter : AttributeConverter<StringMap, String> {
+    override fun convertToDatabaseColumn(attribute: StringMap?): String {
+        return attribute?.map { it.key + ":" + it.value }?.joinToString("\n") ?: ""
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): StringMap {
+        return dbData?.splitToSequence("\n")?.associate { Pair(it.split(":")[0], it.split(":")[1]) } ?: HashMap()
+    }
+}
 
 @Entity
 data class OneToOneSourceEntity(

--- a/annotation-processor/src/test/kotlin/pl/touk/krush/model/EntityGraphBuilderTest.kt
+++ b/annotation-processor/src/test/kotlin/pl/touk/krush/model/EntityGraphBuilderTest.kt
@@ -140,5 +140,21 @@ import javax.lang.model.util.Types
                 .containsKey(enumPropertyEntity(getTypeEnv()))
                 .containsValue(enumPropertyEntityDefinition(getTypeEnv()))
     }
+
+    @Test
+    fun shouldHandleTypeAliases(){
+        //given
+        val typealiasGraphBuilder = typealiasGraphBuilder(getTypeEnv())
+
+        //when
+        val graphs = typealiasGraphBuilder.build()
+
+        //then
+        assertThat(graphs).containsKey("pl.touk.example")
+
+        assertThat(graphs["pl.touk.example"])
+                .containsKey(typealiasEntity(getTypeEnv()))
+                .containsValue(typealiasEntityDefinition(getTypeEnv()))
+    }
 }
 

--- a/example/src/main/kotlin/pl/touk/krush/typealiases/VisitorLog.kt
+++ b/example/src/main/kotlin/pl/touk/krush/typealiases/VisitorLog.kt
@@ -1,0 +1,26 @@
+package pl.touk.krush.typealiases
+
+import javax.persistence.*
+
+typealias VisitorList = List<String>
+typealias PlainString = String
+
+@Entity
+data class VisitorLog(
+        @Id @GeneratedValue
+        val id: Long? = null,
+        @Convert(converter = VisitorListConverter::class)
+        val visitors: VisitorList,
+        val guard: PlainString
+)
+
+@Converter
+class VisitorListConverter : AttributeConverter<VisitorList, String> {
+    override fun convertToDatabaseColumn(attribute: VisitorList?): String {
+        return attribute?.joinToString(",") ?: ""
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): VisitorList {
+        return dbData?.split(",") ?: emptyList()
+    }
+}

--- a/example/src/test/kotlin/pl/touk/krush/typealiases/VisitorLogTest.kt
+++ b/example/src/test/kotlin/pl/touk/krush/typealiases/VisitorLogTest.kt
@@ -1,0 +1,35 @@
+package pl.touk.krush.typealiases
+
+import org.assertj.core.api.Assertions
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.Test
+import pl.touk.krush.base.BaseDatabaseTest
+import pl.touk.krush.types.Event
+import pl.touk.krush.types.EventTable
+import pl.touk.krush.types.insert
+import pl.touk.krush.types.toEventList
+import java.time.*
+import java.util.*
+
+class VisitorLogTest : BaseDatabaseTest() {
+
+    @Test
+    fun shouldHandleTypeAliases() {
+        transaction {
+            SchemaUtils.create(VisitorLogTable)
+
+            // given
+            val log = VisitorLogTable.insert(VisitorLog(visitors = listOf("Krush", "Kotlin", "Gradle" ), guard = "Kelly"))
+
+            //when
+            val logs = (VisitorLogTable)
+                    .select { VisitorLogTable.guard eq "Kelly" }
+                    .toVisitorLogList()
+
+            //then
+            Assertions.assertThat(logs).containsOnly(log)
+        }
+    }
+}

--- a/runtime/src/main/kotlin/pl/touk/krush/WrapperColumn.kt
+++ b/runtime/src/main/kotlin/pl/touk/krush/WrapperColumn.kt
@@ -66,6 +66,17 @@ class StringWrapperColumnType<out Wrapper : Any>(
         is String -> instanceCreator(rawColumnType.valueFromDB(value) as String)
         else -> error("Database value $value of class ${value::class.qualifiedName} is not valid $rawClazz")
     }
+
+    /*
+     * Essentially the same implementation as the superclass however it doesn't auto-unwrap Iterable objects
+     */
+    override fun valueToString(value: Any?): String = when (value) {
+        null -> {
+            check(nullable) { "NULL in non-nullable column" }
+            "NULL"
+        }
+        else -> nonNullValueToString(value)
+    }
 }
 
 inline fun <reified Wrapper : Any> Table.longWrapper(


### PR DESCRIPTION
As the title says, adds support for type aliases.

This should help resolve issue #9 because it becomes possible to do 
```kotlin
typealias StringMap = Map<String, String>
``` 
and have a converter to convert from say `StringMap` to String which krush seems to find acceptable. Then just replace any instances of `Map<String, String>` with `StringMap` and it's off to the races.

This request was written out of a need to resolve issue #9 for a personal project, so it was either this or implement type properties correctly. Please let me know if I am missing any conventions! I didn't write any examples but could probably get some going in short order. Thanks!