### PR TITLE
Fix for naming scheme of M2M IDs

### DIFF
--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/TablesGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/TablesGenerator.kt
@@ -355,10 +355,10 @@ class TablesGenerator : SourceGenerator {
     }
 
     private fun manyToManyPropertyInitializer(
-        id: IdDefinition, idProp: PropertyDefinition, entity: EntityDefinition, differentiatior: String
+        id: IdDefinition, idProp: PropertyDefinition, entity: EntityDefinition, differentiator: String
     ) : CodeBlock {
         val targetTable = entity.tableName
-        val columnName = id.propName(idProp) + differentiatior + "_id"
+        val columnName =  entity.name.asVariable() + differentiator + "_" + id.propName(idProp)
         val idCodeBlock = idCodeBlock(idProp, entity.name, columnName)
 
         return CodeBlock.builder().add(idCodeBlock)

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/TablesGenerator.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/TablesGenerator.kt
@@ -112,7 +112,7 @@ class TablesGenerator : SourceGenerator {
             val name = assoc.targetIdPropName(targetIdProp)
             val columnType = targetIdProp.type.asUnderlyingClassName()
             CodeBlock.builder()
-            val initializer = associationInitializer(assoc, targetIdProp, name)
+            val initializer = associationInitializer(assoc, targetIdProp)
             tableSpec.addProperty(
                 PropertySpec.builder(name, Column::class.asClassName().parameterizedBy(columnType.copy(nullable = true)))
                     .initializer(initializer)
@@ -344,9 +344,9 @@ class TablesGenerator : SourceGenerator {
         }
     }
 
-    private fun associationInitializer(assoc: AssociationDefinition, idProp: PropertyDefinition, idName: String) : CodeBlock {
+    private fun associationInitializer(assoc: AssociationDefinition, idProp: PropertyDefinition) : CodeBlock {
         val columnName = assoc.joinColumns.find { it.name == idProp.columnName.toString() }?.name
-            ?: "${idName}_${assoc.targetId.name.asVariable()}"
+            ?: "${assoc.name.asVariable()}_${assoc.targetId.name.asVariable()}"
         val idCodeBlock = idCodeBlock(idProp, assoc.target.simpleName, columnName)
 
         return CodeBlock.builder().add(idCodeBlock)

--- a/example/src/main/resources/db/migration/V1__tables.sql
+++ b/example/src/main/resources/db/migration/V1__tables.sql
@@ -24,11 +24,11 @@ CREATE TABLE IF NOT EXISTS "character" (
 );
 
 CREATE TABLE IF NOT EXISTS player_characters (
-    id_source_id BIGINT NOT NULL,
-    "characterIdId_target_id" BIGINT NOT NULL,
-    "characterIdSeason_target_id" INT NOT NULL,
+    player_source_id BIGINT NOT NULL,
+    "character_target_characterIdId" BIGINT NOT NULL,
+    "character_target_characterIdSeason" INT NOT NULL,
     CONSTRAINT fk_player_characters_player FOREIGN KEY (id_source_id) REFERENCES player(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
-    CONSTRAINT fk_player_characters_character FOREIGN KEY ("characterIdId_target_id", "characterIdSeason_target_id")
+    CONSTRAINT fk_player_characters_character FOREIGN KEY ("character_target_characterIdId", "character_target_characterIdSeason")
         REFERENCES "character"(id, season) ON DELETE RESTRICT ON UPDATE RESTRICT
 );
 

--- a/example/src/main/resources/db/migration/V1__tables.sql
+++ b/example/src/main/resources/db/migration/V1__tables.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS player_characters (
     player_source_id BIGINT NOT NULL,
     "character_target_characterIdId" BIGINT NOT NULL,
     "character_target_characterIdSeason" INT NOT NULL,
-    CONSTRAINT fk_player_characters_player FOREIGN KEY (id_source_id) REFERENCES player(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    CONSTRAINT fk_player_characters_player FOREIGN KEY (player_source_id) REFERENCES player(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
     CONSTRAINT fk_player_characters_character FOREIGN KEY ("character_target_characterIdId", "character_target_characterIdSeason")
         REFERENCES "character"(id, season) ON DELETE RESTRICT ON UPDATE RESTRICT
 );


### PR DESCRIPTION
The EmbeddedId-PR (#36) switched the column names of M2M IDs from `<target table name> + <source/target> + "id"` to `<target table id column name> + <source/target> + "id"`. 
In non-embedded cases, that caused some not-very-sensible column names to be used, like `id_source_id` and `id_target_id`.

This PR simply switches the naming to a different variant, `<target table name> + <source/target> + <target table id column name>`, which should hopefully be sensible for all use cases.