### PR TITLE
configure dependabot to create PRs for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Sadly we still have problems with the problem described in https://github.com/TouK/krush/issues/54 and it's supposedly fixed in 0.33.1 of exposed. The version included in the latest release of krush is outdated. So instead of updating the dependencies manually again and provide a PR I suggest to have dependabot make pull requests with dependency updates.

Note: I didn't include updates to the github actions, but dependabot can update them as well with the following configuration: 
```
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "daily"
  - package-ecosystem: "gradle"
    directory: "/"
    target-branch: "develop"
    schedule:
      interval: "daily"
```