### PR TITLE
Fix assumption that selfref table ID columns are always named "id"

### DIFF
--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/SelfReferencesFunctions.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/SelfReferencesFunctions.kt
@@ -49,16 +49,16 @@ fun buildToEntityFuncSelf(entityType: TypeElement, entity: EntityDefinition): Fu
 private fun generateAssociationMappings(entity: EntityDefinition) =
     entity.getAssociations(AssociationType.MANY_TO_ONE, AssociationType.ONE_TO_ONE)
         .filter { assoc -> assoc.mapped }
-        .map {
-            val name = it.name
-            val targetName = it.target.simpleName
-            if (!it.nullable) {
+        .map { assoc ->
+            val name = assoc.name
+            val targetName = assoc.target.simpleName
+            if (!assoc.nullable) {
                 "\t$name = this.to$targetName()"
             } else {
-                if (entity.hasSelfReferentialAssoc()) {
-                    "\t$name = this.row[alias[${entity.tableName}.${it.defaultIdPropName()}]]?.let { nextAlias?.let { this.to$targetName(nextAlias, null) } }"
+                if (assoc.isSelfReferential) {
+                    "\t$name = this.row[alias[${entity.tableName}.${assoc.defaultIdPropName()}]]?.let { nextAlias?.let { this.to$targetName(nextAlias, null) } }"
                 } else {
-                    "\t$name = this[alias[${entity.tableName}.${it.defaultIdPropName()}]]?.let { this.to$targetName() }"
+                    "\t$name = this.row[alias[${entity.tableName}.${assoc.defaultIdPropName()}]]?.let { this.to$targetName() }"
                 }
             }
         }

--- a/annotation-processor/src/main/kotlin/pl/touk/krush/source/SelfReferencesFunctions.kt
+++ b/annotation-processor/src/main/kotlin/pl/touk/krush/source/SelfReferencesFunctions.kt
@@ -56,9 +56,9 @@ private fun generateAssociationMappings(entity: EntityDefinition) =
                 "\t$name = this.to$targetName()"
             } else {
                 if (entity.hasSelfReferentialAssoc()) {
-                    "\t$name = this.row[${entity.name}Table.${name}Id]?.let { nextAlias?.let { this.to$targetName(nextAlias, null) } }"
+                    "\t$name = this.row[alias[${entity.tableName}.${it.defaultIdPropName()}]]?.let { nextAlias?.let { this.to$targetName(nextAlias, null) } }"
                 } else {
-                    "\t$name = this[${entity.name}Table.${name}Id]?.let { this.to$targetName() }"
+                    "\t$name = this[alias[${entity.tableName}.${it.defaultIdPropName()}]]?.let { this.to$targetName() }"
                 }
             }
         }

--- a/example/src/main/kotlin/pl/touk/krush/realreferences/Category.kt
+++ b/example/src/main/kotlin/pl/touk/krush/realreferences/Category.kt
@@ -1,19 +1,18 @@
 package pl.touk.krush.realreferences
 
+import java.util.*
 import javax.persistence.*
 
 @Entity
 @Table(name = "category")
 data class Category(
         @Id
-        @GeneratedValue
-        val id: Long? = null,
+        val uuid: UUID = UUID.randomUUID(),
 
         @Column
         val name: String,
 
         @ManyToOne
-        @JoinColumn(name = "parent_id")
         val parent: Category?,
 
         @OneToMany(mappedBy = "parent")

--- a/example/src/main/kotlin/pl/touk/krush/realreferences/Entry.kt
+++ b/example/src/main/kotlin/pl/touk/krush/realreferences/Entry.kt
@@ -1,0 +1,21 @@
+package pl.touk.krush.realreferences
+
+import java.util.*
+import javax.persistence.*
+
+@Entity
+@Table(name = "entry")
+data class Entry(
+    @Id
+    val uuid: UUID = UUID.randomUUID(),
+
+    @Column
+    val name: String = "Data Entry",
+
+    @ManyToOne
+    val category: Category? = null,
+    
+    @JoinTable(name = "related_entries")
+    @ManyToMany
+    val relatedEntries: List<Entry> = emptyList()
+)

--- a/example/src/test/kotlin/pl/touk/krush/realreferences/CategoryTest.kt
+++ b/example/src/test/kotlin/pl/touk/krush/realreferences/CategoryTest.kt
@@ -23,7 +23,7 @@ class CategoryTest: BaseDatabaseTest() {
             val child2 = CategoryTable.insert(Category(name = "child2", parent = parent))
 
             val categories =
-                CategoryTable.join(parentAlias, JoinType.LEFT, CategoryTable.parentId, parentAlias[CategoryTable.id])
+                CategoryTable.join(parentAlias, JoinType.LEFT, CategoryTable.parentUuid, parentAlias[CategoryTable.uuid])
                 .selectAll()
                 .map { it.toCategory(parentAlias) }
 
@@ -31,7 +31,7 @@ class CategoryTest: BaseDatabaseTest() {
                 .containsExactlyInAnyOrder(parent, child1, child2)
 
             val fullCategoryMapping =
-                CategoryTable.join(parentAlias, JoinType.LEFT, CategoryTable.parentId, parentAlias[CategoryTable.id])
+                CategoryTable.join(parentAlias, JoinType.LEFT, CategoryTable.parentUuid, parentAlias[CategoryTable.uuid])
                     .selectAll()
                     .toCategoryList(parentAlias)
 


### PR DESCRIPTION
This PR fixes a smaller naming issue that occurred when using M2O-Relations in a selfreference context.

While working on that, I also noticed that ManyToOne-Annotated lists do not currently get filled out by krush (see for example the `children` attribute in the `Category` example). This should be fixable by applying M2M selfreference logic (or something similar) to M2O relations as well, but I currently do not have a time to properly try that out.